### PR TITLE
Add Separator component, improve dark mode compatibility, and clean up NavBar  

### DIFF
--- a/app/components/custom/navBar.tsx
+++ b/app/components/custom/navBar.tsx
@@ -18,7 +18,6 @@ export const NavBar: FC<NavBarProps> = ({ className, ...props }) => {
   const matches = useMatches();
   const parentMatch = matches[matches.length - 1];
   const pathname = parentMatch?.pathname;
-  console.log(matches);
 
   return (
     <NavigationMenu

--- a/app/components/custom/storageOptions.tsx
+++ b/app/components/custom/storageOptions.tsx
@@ -29,7 +29,7 @@ export const StorageOptions: FC<TStorageOptions> = ({
           key={option}
           value={option}
           aria-label={option}
-          className="bg-gray-100 border border-gray-300 rounded-md data-[state=on]:pointer-events-none data-[state=on]:bg-primary data-[state=on]:text-secondary"
+          className="bg-background border border-gray-300 dark:border-gray-700 rounded-md data-[state=on]:pointer-events-none data-[state=on]:bg-primary data-[state=on]:text-secondary"
         >
           {option}
         </ToggleGroupItem>

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -6,5 +6,6 @@ export * from "./label";
 export * from "./navigation-menu";
 export * from "./pagination";
 export * from "./switch";
+export * from "./separator";
 export * from "./toggle";
 export * from "./toggle-group";

--- a/app/components/ui/separator.tsx
+++ b/app/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/app/routes/product.$productId/route.tsx
+++ b/app/routes/product.$productId/route.tsx
@@ -11,6 +11,7 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
+  Separator,
 } from "@/components/ui";
 import { PriceTag, Rating, StorageOptions } from "@/components/custom";
 
@@ -68,14 +69,15 @@ export default function Product() {
         <CardContent className="flex justify-center my-2">
           <img src={imageUrl} alt={productName} className="max-h-64 max-w-64" />
         </CardContent>
-        <CardContent className="flex justify-center py-4 bg-gray-200">
+        <CardContent className="flex justify-center py-4 bg-slate-100 dark:bg-slate-900">
           <StorageOptions
             options={storageOptions}
             selected={selectedStorage}
             onSelect={handleStorageSelect}
           />
         </CardContent>
-        <CardFooter className="flex flex-col items-center justify-center bg-secondary p-4">
+        <Separator />
+        <CardFooter className="flex flex-col items-center justify-center bg-slate-200 dark:bg-slate-800 p-4">
           <CardDescription className="font-semibold text-primary">
             {countOfPrices} satıcı içinde kargo dahil en ucuz fiyat seçeneği
           </CardDescription>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-navigation-menu": "^1.2.4",
+        "@radix-ui/react-separator": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-switch": "^1.1.2",
         "@radix-ui/react-toggle": "^1.1.1",
@@ -1620,6 +1621,29 @@
         "@radix-ui/react-primitive": "2.0.1",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.1.tgz",
+      "integrity": "sha512-RRiNRSrD8iUiXriq/Y5n4/3iE8HzqgLHsusUSg5jVpU2+3tqcUFPJXHDymwEypunc2sWxDUS3UC+rkZRlHedsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-navigation-menu": "^1.2.4",
+    "@radix-ui/react-separator": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-toggle": "^1.1.1",


### PR DESCRIPTION
This PR adds the `shadcn` Separator component using Radix UI to enhance UI structuring. The `StorageOptions` component is updated with improved class names for better dark mode compatibility and refined layout within the product route. Additionally, an unnecessary `console.log` statement is removed from the NavBar component to clean up the codebase.

- add shadcn Separator component using Radix UI  
- update class names for dark mode compatibility and improve layout in product route  
- remove console.log statement for matches array in NavBar 